### PR TITLE
Changes part 3

### DIFF
--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -138,7 +138,7 @@ $response | ConvertTo-Json
 }
 ```
 
-Use this endpoint to Register a new Individual User.
+Use this endpoint to register a new individual user.
 
 ### HTTP Request
 
@@ -146,13 +146,13 @@ Use this endpoint to Register a new Individual User.
 
 ### Parameters
 
-Parameter                                                         | Default   | Description
------------------------------------------------------------------ | --------- | -------------------
-<strong>email</strong><strong>required</strong>                   | N/A       | Email Address
-<strong>first_name</strong><strong>required</strong>               | N/A       | First Name
-<strong>last_name</strong><strong>required</strong>               | N/A       | Last Name
-<strong>password</strong><strong>required</strong>                | N/A       | Password
-<strong>password_confirmation</strong><strong>required</strong>    | N/A       | Password Confirmation
+Parameter                                                       | Default   | Description
+----------------------------------------------------------------| --------- | -------------------
+<strong>email</strong><strong>required</strong>                 | N/A       | Email Address
+<strong>first_name</strong><strong>required</strong>            | N/A       | First Name
+<strong>last_name</strong><strong>required</strong>             | N/A       | Last Name
+<strong>password</strong><strong>required</strong>              | N/A       | Password
+<strong>password_confirmation</strong><strong>required</strong> | N/A       | Password Confirmation
 
 ## Sign In
 
@@ -417,7 +417,7 @@ $response | ConvertTo-Json
 }
 ```
 
-Use this endpoint to finish the session and discard the access_token acquired on the sign in API call
+Use this endpoint to finish the session and discard the `access_token` acquired on the sign in API call.
 
 ### HTTP Request
 
@@ -425,4 +425,4 @@ Use this endpoint to finish the session and discard the access_token acquired on
 
 ### Parameters
 
-This API doesnot require any parameter.
+No parameters required.

--- a/source/includes/_plans.md
+++ b/source/includes/_plans.md
@@ -1,8 +1,8 @@
 # Plans
 
-A Health Insurance Plan (aka Plan) is the specifics of a Health Insurance (aka medical insurance, healthcare insurance) which specify the rules and regulations, the different benefits it covers, what it doesn't cover, cost of the policy holder's medical expenses, how much the policy holder pays vs how much the insurance covers and the scenarios of the same, etc.,
+A health insurance plan (AKA Plan) is the specifics of an insurance plan (e.g. medical insurance, healthcare insurance). It specifies the rules and regulations, the different benefits it covers, what it doesn't cover, cost of the policy holder's medical expenses, how much the policy holder pays vs how much the insurance covers, etc.
 
-This section of the API Doc helps with various aspects of fetching, selecting, unselecting different types of plans for the given [Quote](#quotes)
+This section of the API Doc helps with various aspects of fetching, selecting, and unselecting different types of plans for the given [Quote](#quotes).
 
 ## Get Available Plans
 
@@ -339,7 +339,7 @@ $response | ConvertTo-Json
 ]
 ```
 
-Use this endpoint to get all the available plans for the quote. A list of plans should be returned. In the example there's only one plan, since the json is pretty long, but usually there are several plans.
+Use this endpoint to get all the available plans for the quote. In the example there's only one plan, but usually there are several plans.
 
 <aside class="notice">
   This endpoint is <strong><i>secured</i></strong> and requires <strong><i> Authorization headers</i></strong>. 
@@ -474,7 +474,7 @@ $response | ConvertTo-Json
 ]
 ```
 
-Use this endpoint to list the prices for the plans. A list of prices should be returned. In the example there's only one price, since the json is pretty long, but usually there are several prices.
+Use this endpoint to list the prices for the plans. In the example there's only one price, but usually there are several prices.
 
 <aside class="notice">
   This endpoint is <strong><i>secured</i></strong> and requires <strong><i> Authorization headers</i></strong>. 
@@ -620,7 +620,7 @@ $response | ConvertTo-Json
 ]
 ```
 
-Use this endpoint to retrieve quote's plan selections. It could be up to 4 elements / 4 plan selections.
+Use this endpoint to retrieve a quote's plan selections. A quote can include up to four selected plans.
 
 <aside class="notice">
   This endpoint is <strong><i>secured</i></strong> and requires <strong><i> Authorization headers</i></strong>. 

--- a/source/includes/_quotes.md
+++ b/source/includes/_quotes.md
@@ -1,8 +1,8 @@
 # Quotes
 
-Quote is an inquiry made for an individual where one or more Health insurance plans selected for a the given Individual.
+A quote is an inquiry made for an individual where one or more health insurance plans are selected for a the given individual.
 
-* An inquiry could have more than one plan (upto 4)
+* An inquiry can have up to 4 plans.
 
 Steps include to create an inquiry as follows.
 
@@ -233,11 +233,13 @@ Use this endpoint to create a new quote.
 
 Parameter                                                                    | Default   | Description
 -----------------------------------------------------------------------------| --------- | -----------
-<strong>effective_date</strong><strong>required</strong>                     | N/A       |
-<strong>zip_code</strong><strong>required</strong>                           | N/A       |
-<strong>county_code</strong><strong>required</strong>                        | N/A       |
-<strong>income</strong><strong>required</strong>                             | N/A       |
-<strong>family_members_attributes</strong><strong>required</strong>          | N/A       | Array of { "first_name": "", "last_name": "", "email": "", "date_of_birth": "mm/dd/yyyy", "relationship": "Primary", "smoker": boolean, "declared_medicare": boolean, "declared_dependent": boolean }
+<strong>quote[effective_date]</strong><strong>required</strong>                     | N/A       |
+<strong>quote[zip_code]</strong><strong>required</strong>                           | N/A       |
+<strong>quote[county_id]</strong><strong>required</strong>                        | N/A       |
+<strong>quote[broker_code]</strong><strong>required</strong>                        | N/A       |
+<strong>quote[entered_additional_hh_members]</strong><strong>required</strong>                        | N/A       |
+<strong>quote[income]</strong><strong>required</strong>                             | N/A       |
+<strong>quote[family_members_attributes]</strong><strong>required</strong>          | N/A       | Array of { "first_name": "", "last_name": "", "email": "", "date_of_birth": "mm/dd/yyyy", "relationship": "Primary", "smoker": boolean, "declared_medicare": boolean, "declared_dependent": boolean }
 
 ## Update a Quote
 
@@ -461,11 +463,13 @@ Use this endpoint to update an quote.
 
 Parameter                                                                    | Default   | Description
 -----------------------------------------------------------------------------| --------- | -----------
-<strong>effective_date</strong><strong>required</strong>                     | N/A       |
-<strong>zip_code</strong><strong>required</strong>                           | N/A       |
-<strong>county_code</strong><strong>required</strong>                        | N/A       |
-<strong>income</strong><strong>required</strong>                             | N/A       |
-<strong>family_members_attributes</strong><strong>required</strong>          | N/A       | Array of { "first_name": "", "last_name": "", "email": "", "date_of_birth": "mm/dd/yyyy", "relationship": "Primary", "smoker": boolean, "declared_medicare": boolean, "declared_dependent": boolean }
+<strong>quote[effective_date]</strong><strong>required</strong>                     | N/A       |
+<strong>quote[zip_code]</strong><strong>required</strong>                           | N/A       |
+<strong>quote[county_id]</strong><strong>required</strong>                        | N/A       |
+<strong>quote[broker_code]</strong><strong>required</strong>                        | N/A       |
+<strong>quote[entered_additional_hh_members]</strong><strong>required</strong>                        | N/A       |
+<strong>quote[income]</strong><strong>required</strong>                             | N/A       |
+<strong>quote[family_members_attributes]</strong><strong>required</strong>          | N/A       | Array of { "first_name": "", "last_name": "", "email": "", "date_of_birth": "mm/dd/yyyy", "relationship": "Primary", "smoker": boolean, "declared_medicare": boolean, "declared_dependent": boolean }
 
 ## Get a Quote
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -25,13 +25,12 @@ search: true
 
 Welcome to the Wellthie Affordable Care Advisor (Individual) API Documentation.
 
-The Wellthie Affordable Care Advisor is a tool that helps you plan for and estimate costs of your insurance options, based on the Affordable Care Act (ACA). One can also understand if they may be eligible for any financial assistance and estimate the potential penalty for not having insurance for ongoing period / year. By entering your zip code, date of birth, family members and household income, the Wellthie Individual presents insurance options and makes calculations based on the ACA, state regulations and approved insurance rates. The calculations are estimates only, based on the information you provide. You will also get a list of important things to remember such as key dates, where to apply for insurance and who to call to get assistance.
+The Wellthie Affordable Care Advisor is a tool that helps you plan for and estimate costs of your insurance options based on the Affordable Care Act (ACA). One can also understand if they may be eligible for any financial assistance and estimate the potential penalty for not having insurance for an ongoing period/year. By entering your zip code, date of birth, family members and household income, the Wellthie Individual platform presents insurance options and makes calculations based on the ACA, state regulations and approved insurance rates. The calculations are estimates only, based on the information you provide. You will also get a list of important things to remember such as key dates, where to apply for insurance and who to call to get assistance.
 
-Wellthie helps Individuals to discover health insurance online! [Wellthie](https://wellthie.affordablecareadvisor.com) is transforming the insurance shopping experience by helping Individuals discover health insurance online. It’s easy to find the best plans for your budget in minutes.
+[Wellthie](https://wellthie.affordablecareadvisor.com) helps individuals to discover health insurance online! It’s easy to find the best plans for your budget in minutes.
 
-* The Wellthie Individual API is built based on [REST](https://en.wikipedia.org/wiki/Representational_state_transfer).
-* Wellthie Individual API is resource-oriented, and uses HTTP response codes to indicate API status & errors. We use built-in HTTP features, like HTTP verbs, which are understood by off-the-shelf HTTP clients.
-* Wellthie Individual API uses JWT token Based authentication which we'll learn in next section
+* Wellthie Individual is a [REST](https://en.wikipedia.org/wiki/Representational_state_transfer) API.
+* Wellthie Individual API uses JWT token-based authentication.
 * JSON is returned by all API responses, including errors.
 
 ## Audience
@@ -51,7 +50,7 @@ This Documentation for Wellthie Individual API is specifically intended for deve
 
 ## API Base URL
 
-Examples in this document will reference the Wellthie demo site at wellthie-qa.affordablecareadvisor.net whose API base URL is therefore 
+Examples in this document will reference the Wellthie whose API base URL is
 
 `https://wellthie-qa.affordablecareadvisor.net/api/`.
 
@@ -92,16 +91,14 @@ Examples in this document will reference the Wellthie demo site at wellthie-qa.a
 }
 ```
 
-<aside class="notice">Wellthie Individual App uses a <a href="https://jwt.io/introduction/">JWT Based Token Authentication Mechanism</a></aside>
-
-This app uses JWT token based authentication [Oauth 2.0 RFC](https://tools.ietf.org/html/rfc6750). Each protected request is expected to include the `Authorization` header with the access_token value.
+This app uses JWT token-based authentication (see [Oauth 2.0 RFC](https://tools.ietf.org/html/rfc6750)). Each protected request is expected to include the `Authorization` header with the `access_token` value.
 
 When you [sign in](#sign-in) the response would include `access_token` as part of the `data` in case of a successful login. 
 
 The Header should set the following values…
 
-1. Authorization Bearer [access_token value]
-2. Content-Type = application/json
+1. `Authorization Bearer [access_token value]`
+2. `Content-Type` set to `application/json`
 
 <aside class="notice">
 A Bearer Token is set in the Authorization header of every Inline Action HTTP Request.


### PR DESCRIPTION
Some specific comments:

* Get rid of the error section altogether?
* We say the base URL is `.../api` but all our endpoints are e.g. `POST /api/sign_in`. We should have it so when the endpoint is concatenated with the API base it works
* We say that application/json is required for everything but we have curl calls without it
* Should we really even tell the users where the examples are coming from? Should they even be allowed to know about the QA environment?
    * If the above is ok then maybe just change it to "The base URL for all API calls is blah blah..."

